### PR TITLE
Add newline insertion to extract function

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,8 @@
                  [org.clojure/clojurescript "1.7.228"]
                  [org.clojure/core.async "0.2.374" :exclusions [org.clojure/tools.reader]]
                  [rewrite-cljs "0.4.0" :exclusions [org.clojure/tools.reader]]
-                 [cljfmt "0.4.0"]]
+                 [cljfmt "0.4.0"]
+                 [fipp "0.6.4"]]
 
   :npm {:dependencies [[source-map-support "0.3.3"]
                        [ws "1.0.1"]]}

--- a/src/clj_refactor/transform.cljs
+++ b/src/clj_refactor/transform.cljs
@@ -14,7 +14,8 @@
    [rewrite-clj.zip.findz :as zf]
    [rewrite-clj.zip.removez :as zr]
    [rewrite-clj.zip.utils :as zu]
-   [rewrite-clj.zip.whitespace :as ws]))
+   [rewrite-clj.zip.whitespace :as ws]
+   [fipp.clojure :as fipp]))
 
 (defn introduce-let
   "Adds a let around the current form."
@@ -273,6 +274,13 @@
       (z/insert-left `(~'defn ~fn-name [~@args])) ; add declare
       (z/insert-left (n/newline-node "\n\n"))))) ; add new line after location
 
+(defn pretty-up-form
+  [form]
+  (z/node
+    (z/of-string
+      (with-out-str
+        (fipp/pprint form {:width 1})))))
+
 (defn extract-function
   [zloc [fn-name used-locals]]
   (let [expr-loc (z/up (edit/find-op zloc))
@@ -283,7 +291,7 @@
       (z/replace `(~fn-sym ~@used-syms))
       (edit/mark-position :new-cursor)
       (edit/to-root)
-      (z/insert-left `(~'defn ~fn-sym [~@used-syms] ~expr))
+      (z/insert-left (pretty-up-form `(~'defn ~fn-sym [~@used-syms] ~expr)))
       (z/insert-left (n/newline-node "\n\n"))
       (z/left)
       (z/up))))


### PR DESCRIPTION
I've spammed you about this on slack already. :stuck_out_tongue: 

I've only added it to the extract function for now, as that's my main use. But I see no reason this couldn't be extended to other applications where it seems appropriate. I've chosen `{width: 1}` because it tells fipp to try and keep it short.

Rewrite-clj seems to have a significantly better implementation, maybe we should look at accessing that over the nrepl at some time.